### PR TITLE
Fix vagrant up machine order

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ To test bleeding-edge Master releases of DC/OS it may be necessary to use the ma
     Specify which machines to deploy. For example (requires 5.5GB free memory):
 
     ```bash
-    vagrant up m1 a1 p1 boot
+    vagrant up boot m1 a1 p1
     ```
 
     Many permutations of machines are possible. See [Example Clusters](#example-clusters) for more options.
@@ -241,7 +241,7 @@ Each machine in `VagrantConfig.yaml` must specify one of the following node type
 
 Which exact machines are created and provisioned can be specified in one of two ways:
 
-1. Specify the machines by name when deploying (e.g. `vagrant up m1 a1 p1 boot`)
+1. Specify the machines by name when deploying (e.g. `vagrant up boot m1 a1 p1`)
 1. Remove the unwanted machines from the `VagrantConfig.yaml` file and deploy them all with `vagrant up`
 
 Generally option 1 is recommended to avoid having to modify the `VagrantConfig.yaml` file.
@@ -277,7 +277,7 @@ Adding a node will not immediately change scheduled services by may allow pendin
 
 ```
 # Example initial cluster deploy
-vagrant up m1 a1 p1 boot
+vagrant up boot m1 a1 p1
 # Add a private agent node
 vagrant up a2
 # Add a public agent node
@@ -290,7 +290,7 @@ Removing an agent node will cause all tasks running on that node to be reschedul
 
 ```
 # Example initial cluster deploy
-vagrant up m1 a1 p1 boot
+vagrant up boot m1 a1 p1
 # Remove a private agent node
 vagrant destroy -f a1
 # Remove a public agent node
@@ -334,7 +334,7 @@ A minimal cluster supports launching small Marathon apps. Most other services wi
 Requires > 4.5GB free memory (using the example [VagrantConfig](./VagrantConfig.yaml.example)).
 
 ```bash
-vagrant up m1 a1 boot
+vagrant up boot m1 a1
 ```
 
 ## Small Cluster
@@ -344,7 +344,7 @@ A small cluster supports running tasks on multiple nodes.
 Requires > 7.25GB free memory (using the example [VagrantConfig](./VagrantConfig.yaml.example)).
 
 ```bash
-vagrant up m1 a1 a2 p1 boot
+vagrant up boot m1 a1 a2 p1
 ```
 
 ## Medium Cluster
@@ -354,7 +354,7 @@ A medium cluster supports the installation of a [minimally configured Cassandra]
 Requires > 10GB free memory (using the example [VagrantConfig](./VagrantConfig.yaml.example)).
 
 ```bash
-vagrant up m1 a1 a2 a3 a4 p1 boot
+vagrant up boot m1 a1 a2 a3 a4 p1
 ```
 
 ## Large Cluster
@@ -364,7 +364,7 @@ Requires > 17GB free memory (using the example [VagrantConfig](./VagrantConfig.y
 A large cluster supports master node fail over, multiple framework installs, and multiple public load balancers.
 
 ```bash
-vagrant up m1 m2 m3 a1 a2 a3 a4 a5 a6 p1 p2 p3 boot
+vagrant up boot m1 m2 m3 a1 a2 a3 a4 a5 a6 p1 p2 p3
 ```
 
 # Environment Options


### PR DESCRIPTION
Vagrant Up commands should have `boot` machine start first...not last.
